### PR TITLE
refactor: Update Dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
 
 - package-ecosystem: npm


### PR DESCRIPTION
## Issue
Dpeendabot generates a lot of noise recently. This is not so important for demo projects

## Solution
Update Dependabot schedule from weekly to monthly.